### PR TITLE
Add support for Meteor 0.8.3

### DIFF
--- a/editable.js
+++ b/editable.js
@@ -27,8 +27,14 @@ mEditable = {
                 return typeof t === 'object';
             })
         });
+        
         // store only the template name
-        type.template = type.template.__templateName;
+        if (!type.template.kind) {
+            type.template = type.template.__templateName;
+        } else {
+            type.template = type.template.kind.replace(/^Template_/, '');
+        }
+        
         return this._types.insert(type);
     }
 };


### PR DESCRIPTION
I'm not sure if this is the best way to fix this but I ran into problems when updating to Meteor 0.8.3 and found that I needed to make these necessary changes. If you have a better way, please use your own fix instead.

The main problem is that the `template` object does not have the `kind` property anymore.
